### PR TITLE
Add phase 1 CI and release process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Copenhagen
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+      ngrx:
+        patterns:
+          - "@ngrx/*"
+      testing-tooling:
+        patterns:
+          - "@types/*"
+          - jasmine-core
+          - karma*
+          - typescript
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Copenhagen
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Run unit tests
+        run: npm run test:ci
+        env:
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}

--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -1,0 +1,33 @@
+# Branch protection
+
+This repository currently protects `develop` only. That is enough for the current solo-maintainer phase and still matches the intent of the broader branching strategy.
+
+## Recommended `develop` settings
+
+Enable the following settings for `develop` in GitHub:
+
+- Require a pull request before merging
+- Do not require approvals
+- Require status checks to pass before merging
+- Require conversation resolution before merging
+- Require linear history
+- Do not allow force pushes
+- Do not allow branch deletion
+
+## Required status checks
+
+Use these checks from the CI workflow:
+
+- `build`
+- `test`
+
+Approvals stay off on purpose because a pull request author cannot approve their own pull request. In a solo workflow, PR + CI gives control without creating a dead end.
+
+## Later expansion
+
+When the repository is ready for the full strategy, add equivalent protection to:
+
+- `test`
+- `main`
+
+At that point, keep the same pull-request requirement and CI checks, and decide whether `main` should be stricter than `develop`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# Releasing
+
+This repository is currently in a phase 1 workflow where `develop` is the only protected branch.
+
+## Current flow
+
+1. Create a `feature/*` branch from `develop`.
+2. Open a pull request back into `develop`.
+3. Wait for the `build` and `test` checks to pass.
+4. Merge through the pull request.
+
+Approval requirements are intentionally disabled in this phase so the workflow works for a solo maintainer.
+
+## Versioning
+
+Use Semantic Versioning: `MAJOR.MINOR.PATCH`.
+
+While the repository only has `develop`, treat versions as template milestones or preview releases instead of production releases.
+
+If you need a shareable tagged snapshot before `test` and `main` exist, use a pre-release tag on `develop`, for example:
+
+- `v0.3.0-beta.1`
+- `v0.3.0-rc.1`
+
+## GitHub releases
+
+When you create a tagged milestone, prefer GitHub Releases with auto-generated release notes. That keeps dependency upgrades, fixes, and template changes easy to review later.
+
+## Planned expansion
+
+When `test` and `main` are added, move to the full strategy:
+
+1. `feature/*` -> `develop`
+2. `develop` -> `test`
+3. `fix/*` from `test` when stabilization is needed
+4. `test` -> `main`
+5. Final release tags on `main`

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,6 +32,12 @@ module.exports = function (config) {
         { type: 'text-summary' }
       ]
     },
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-dev-shm-usage']
+      }
+    },
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCI",
     "compodoc": "compodoc -p tsconfig.doc.json"
   },
   "private": true,


### PR DESCRIPTION
## Summary
This PR adds the first process-focused setup for the Angular template while the repository is still using a develop-only workflow.

## Changes
- add GitHub Actions CI for `build` and `test` on `develop`
- add Dependabot configuration targeting `develop`
- add `RELEASING.md` for the current phase 1 workflow
- add `BRANCH_PROTECTION.md` with recommended GitHub settings
- add a `test:ci` script and a `ChromeHeadlessCI` Karma launcher for stable CI test runs

## Verification
- `npm run build`
- `npm run test:ci`

## Notes
- this is intentionally aligned with the temporary `develop`-only setup
- the documentation is written so it can later be expanded to the full `develop -> test -> main` strategy
