### PR TITLE
Migrate Angular build to browser-esbuild

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:browser-esbuild",
           "options": {
             "outputPath": "dist/AngularTemplate",
             "index": "src/index.html",
@@ -61,7 +61,6 @@
             "development": {
               "buildOptimizer": false,
               "optimization": false,
-              "vendorChunk": true,
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true,
@@ -75,7 +74,6 @@
             "mock": {
               "buildOptimizer": false,
               "optimization": false,
-              "vendorChunk": true,
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true,


### PR DESCRIPTION
## Summary
This PR takes the next incremental modernization step for the template by moving the Angular build target from the legacy webpack-based `browser` builder to `browser-esbuild`.

## Changes
- switch the application build target to `@angular-devkit/build-angular:browser-esbuild`
- remove `vendorChunk` from `development` and `mock` because it is not used by the esbuild-based builder
- keep the rest of the application structure unchanged to make this a low-risk migration step

## Verification
- `npm run build`
- `ng build --configuration=development`
- `ng build --configuration=mock`
- `npm run test:ci`

## Notes
- production build still works after the migration
- development and mock configurations still build correctly
- the production initial bundle is now below the current `1mb` warning budget
- this is intended as the foundation for a later Vitest migration
