### PR TITLE
Modernize NgRx sample feature pattern

### DIFF
--- a/src/app/modules/features/sample-records/components/sample-records-page/sample-records-page.component.spec.ts
+++ b/src/app/modules/features/sample-records/components/sample-records-page/sample-records-page.component.spec.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
 import { SampleRecordsComponent } from '../sample-records/sample-records.component';
 import { SampleRecordsPageComponent } from './sample-records-page.component';
+import { SampleRecordsFacade } from '../../state/sample-records.facade';
+import type { Mocked } from 'vitest';
 
 @Component({
   selector: 'app-sample-records',
@@ -16,12 +18,19 @@ export class SampleRecordsStubComponent {
 describe('SampleRecordsPageComponent', () => {
   let component: SampleRecordsPageComponent;
   let fixture: ComponentFixture<SampleRecordsPageComponent>;
-  let store: MockStore;
+  let sampleRecordsFacade: Mocked<Pick<SampleRecordsFacade, 'sampleRecords$' | 'loadSampleRecords'>>;
 
   beforeEach(async () => {
+    sampleRecordsFacade = {
+      sampleRecords$: of([]),
+      loadSampleRecords: vi.fn()
+    } as unknown as Mocked<Pick<SampleRecordsFacade, 'sampleRecords$' | 'loadSampleRecords'>>;
+
     const testBed = TestBed.configureTestingModule({
       imports: [SampleRecordsPageComponent, SampleRecordsStubComponent],
-      providers: [provideMockStore()]
+      providers: [
+        { provide: SampleRecordsFacade, useValue: sampleRecordsFacade }
+      ]
     });
 
     testBed.overrideComponent(SampleRecordsPageComponent, {
@@ -37,8 +46,6 @@ describe('SampleRecordsPageComponent', () => {
   });
 
   beforeEach(() => {
-    
-    store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(SampleRecordsPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -46,5 +53,9 @@ describe('SampleRecordsPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load sample records on init', () => {
+    expect(sampleRecordsFacade.loadSampleRecords).toHaveBeenCalled();
   });
 });

--- a/src/app/modules/features/sample-records/components/sample-records-page/sample-records-page.component.ts
+++ b/src/app/modules/features/sample-records/components/sample-records-page/sample-records-page.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { SampleRecordsComponent } from '../sample-records/sample-records.component';
-import { loadSampleRecords } from '../../state/actions/sample-record.actions';
-import * as fromSampleRecords from '../../state/selectors/sample-record.selectors';
+import { SampleRecordsFacade } from '../../state/sample-records.facade';
 
 /**
  * Component for displaying sample records.
@@ -19,15 +17,15 @@ import * as fromSampleRecords from '../../state/selectors/sample-record.selector
 export class SampleRecordsPageComponent implements OnInit {
 
   /** An observable that emits the sample records. */
-  sampleRecords$ = this.store.select(fromSampleRecords.selectSampleRecordList);
+  sampleRecords$ = this.sampleRecordsFacade.sampleRecords$;
 
   /**
    * Creates an instance of SampleRecordsPageComponent.
    * @constructor
-   * @param {Store} store - The NgRx store.
+   * @param {SampleRecordsFacade} sampleRecordsFacade - Facade for sample-record state access.
    */
   constructor(
-    private store: Store,
+    private sampleRecordsFacade: SampleRecordsFacade,
   ) { }
 
   /**
@@ -39,11 +37,11 @@ export class SampleRecordsPageComponent implements OnInit {
   }
 
   /**
-   * Dispatches an action to load sample records from the store.
+   * Requests sample records through the feature facade.
    * @returns {void}
    */
   loadRecords(): void {
-    this.store.dispatch(loadSampleRecords());
+    this.sampleRecordsFacade.loadSampleRecords();
   }
 
 }

--- a/src/app/modules/features/sample-records/sample-records.routes.ts
+++ b/src/app/modules/features/sample-records/sample-records.routes.ts
@@ -3,14 +3,14 @@ import { provideState } from '@ngrx/store';
 import { Routes } from '@angular/router';
 import { SampleRecordsPageComponent } from './components/sample-records-page/sample-records-page.component';
 import { SampleRecordEffects } from './state/effects/sample-record.effects';
-import { reducer, sampleRecordsFeatureKey } from './state/reducers/sample-record.reducer';
+import { sampleRecordsFeature } from './state/reducers/sample-record.reducer';
 
 export const SAMPLE_RECORDS_ROUTES: Routes = [
   {
     path: '',
     component: SampleRecordsPageComponent,
     providers: [
-      provideState(sampleRecordsFeatureKey, reducer),
+      provideState(sampleRecordsFeature),
       provideEffects(SampleRecordEffects)
     ]
   }

--- a/src/app/modules/features/sample-records/state/reducers/sample-record.reducer.spec.ts
+++ b/src/app/modules/features/sample-records/state/reducers/sample-record.reducer.spec.ts
@@ -1,24 +1,9 @@
-import { TestBed } from '@angular/core/testing';
-import { reducer, initialState, sampleRecordsReducer } from './sample-record.reducer';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { initialState, reducer, sampleRecordAdapter, sampleRecordsReducer } from './sample-record.reducer';
 import { loadSampleRecords, loadSampleRecordsFailure, loadSampleRecordsSuccess } from '../actions/sample-record.actions';
 import { LoadingState } from 'src/app/modules/core/utils/call-state';
 import { MockSampleRecord } from '../mock-models';
 
 describe('Sample Record Reducer', () => {
-  let store: any;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        provideMockStore({ initialState }),
-      ]
-    });
-
-    store = TestBed.inject(MockStore);
-  });
-
-
   describe('an unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
@@ -42,7 +27,7 @@ describe('Sample Record Reducer', () => {
     const state = sampleRecordsReducer(initialState, action);
   
     expect(state.callState).toBe(LoadingState.LOADED);
-    expect(state.data).toEqual(mockSampleRecords);
+    expect(sampleRecordAdapter.getSelectors().selectAll(state)).toEqual(mockSampleRecords);
   });
 
   it('should set the call state to the error when loading sample records fails', () => {

--- a/src/app/modules/features/sample-records/state/reducers/sample-record.reducer.ts
+++ b/src/app/modules/features/sample-records/state/reducers/sample-record.reducer.ts
@@ -1,18 +1,8 @@
-import { Action, createReducer, on } from '@ngrx/store';
+import { createFeature, createReducer, createSelector, on } from '@ngrx/store';
+import { createEntityAdapter, EntityState } from '@ngrx/entity';
 import { SampleRecord } from '../../models/sample-record.interface';
 import * as SampleRecordActions from '../actions/sample-record.actions';
-import { IState, LoadingState } from 'src/app/modules/core/utils/call-state';
-
-/**
- * Reducer function for managing the sample-record state.
- * @function
- * @param {State} state - The current state.
- * @param {Action} action - The current action.
- * @returns {State} The new state.
- */
-export function reducer(state: State, action: Action) {
-  return sampleRecordsReducer(state, action);
-}
+import { CallState, LoadingState, getError } from 'src/app/modules/core/utils/call-state';
 
 /**
  * The key for the sample-record feature state.
@@ -20,21 +10,23 @@ export function reducer(state: State, action: Action) {
  */
 export const sampleRecordsFeatureKey = 'sampleRecords';
 
+export const sampleRecordAdapter = createEntityAdapter<SampleRecord>();
+const sampleRecordSelectors = sampleRecordAdapter.getSelectors();
+
 /**
  * The initial state for the sample-record feature state.
  * @constant {State}
  */
 export const initialState: State = {
-  data: [],
-  callState: LoadingState.INIT
+  ...sampleRecordAdapter.getInitialState({ callState: LoadingState.INIT }),
 };
 
 /**
  * Interface for the sample-record feature state.
  * @interface
- * @extends {IState<SampleRecord[]>}
  */
-export interface State extends IState<SampleRecord[]> {
+export interface State extends EntityState<SampleRecord> {
+  callState: CallState;
 }
 
 /**
@@ -43,17 +35,18 @@ export interface State extends IState<SampleRecord[]> {
  * @constant {Reducer<State>} sampleRecordsReducer
  */
 export const sampleRecordsReducer = createReducer(
-  initialState, on(
+  initialState,
+  on(
     SampleRecordActions.loadSampleRecords,
     (state) => ({ ...state, callState: LoadingState.LOADING })
   ),
   on(
     SampleRecordActions.loadSampleRecordsSuccess,
-    (state, { data }) => ({
-      ...state,
-      data,
-      callState: LoadingState.LOADED
-    })
+    (state, { data }) =>
+      sampleRecordAdapter.setAll(data, {
+        ...state,
+        callState: LoadingState.LOADED
+      })
   ),
   on(
     SampleRecordActions.loadSampleRecordsFailure,
@@ -61,6 +54,51 @@ export const sampleRecordsReducer = createReducer(
       ...state,
       callState: { errorMsg }
     })
-  )
+  ),
 );
+
+export const sampleRecordsFeature = createFeature({
+  name: sampleRecordsFeatureKey,
+  reducer: sampleRecordsReducer,
+  extraSelectors: ({ selectCallState, selectSampleRecordsState }) => ({
+    selectSampleRecordIds: createSelector(
+      selectSampleRecordsState,
+      (state) => sampleRecordSelectors.selectIds(state)
+    ),
+    selectSampleRecordEntities: createSelector(
+      selectSampleRecordsState,
+      (state) => sampleRecordSelectors.selectEntities(state)
+    ),
+    selectSampleRecordList: createSelector(
+      selectSampleRecordsState,
+      (state) => sampleRecordSelectors.selectAll(state)
+    ),
+    selectSampleRecordTotal: createSelector(
+      selectSampleRecordsState,
+      (state) => sampleRecordSelectors.selectTotal(state)
+    ),
+    getSampleRecordsError: createSelector(selectCallState, getError),
+    sampleRecordsIsLoading: createSelector(
+      selectCallState,
+      (callState) => callState === LoadingState.LOADING
+    ),
+    sampleRecordsIsLoaded: createSelector(
+      selectCallState,
+      (callState) => callState === LoadingState.LOADED
+    ),
+  }),
+});
+
+export const {
+  reducer,
+  selectCallState,
+  selectSampleRecordsState,
+  selectSampleRecordIds,
+  selectSampleRecordEntities,
+  selectSampleRecordList,
+  selectSampleRecordTotal,
+  getSampleRecordsError,
+  sampleRecordsIsLoading,
+  sampleRecordsIsLoaded,
+} = sampleRecordsFeature;
 

--- a/src/app/modules/features/sample-records/state/sample-records.facade.spec.ts
+++ b/src/app/modules/features/sample-records/state/sample-records.facade.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { SampleRecordsFacade } from './sample-records.facade';
+import { loadSampleRecords } from './actions/sample-record.actions';
+
+describe('SampleRecordsFacade', () => {
+  let facade: SampleRecordsFacade;
+  let store: MockStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()]
+    });
+
+    facade = TestBed.inject(SampleRecordsFacade);
+    store = TestBed.inject(MockStore);
+  });
+
+  it('should dispatch loadSampleRecords', () => {
+    vi.spyOn(store, 'dispatch');
+
+    facade.loadSampleRecords();
+
+    expect(store.dispatch).toHaveBeenCalledWith(loadSampleRecords());
+  });
+});

--- a/src/app/modules/features/sample-records/state/sample-records.facade.ts
+++ b/src/app/modules/features/sample-records/state/sample-records.facade.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { loadSampleRecords } from './actions/sample-record.actions';
+import * as fromSampleRecords from './selectors/sample-record.selectors';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SampleRecordsFacade {
+  readonly sampleRecords$ = this.store.select(fromSampleRecords.selectSampleRecordList);
+  readonly isLoading$ = this.store.select(fromSampleRecords.sampleRecordsIsLoading);
+  readonly isLoaded$ = this.store.select(fromSampleRecords.sampleRecordsIsLoaded);
+  readonly error$ = this.store.select(fromSampleRecords.getSampleRecordsError);
+
+  constructor(private store: Store) {}
+
+  loadSampleRecords(): void {
+    this.store.dispatch(loadSampleRecords());
+  }
+}

--- a/src/app/modules/features/sample-records/state/selectors/sample-record.selectors.spec.ts
+++ b/src/app/modules/features/sample-records/state/selectors/sample-record.selectors.spec.ts
@@ -1,52 +1,51 @@
 
-
 import { LoadingState } from 'src/app/modules/core/utils/call-state';
 import { MockSampleRecord } from '../mock-models';
 import { getSampleRecordsError, sampleRecordsIsLoaded, sampleRecordsIsLoading, selectSampleRecordList } from './sample-record.selectors';
-import { State } from '../reducers/sample-record.reducer';
+import { initialState, sampleRecordAdapter, State } from '../reducers/sample-record.reducer';
 
 describe('Sample record selectors', () => {
   const mockSampleRecord = new MockSampleRecord();
   const loadingState = {
-      data: [],
-      callState: LoadingState.LOADING
-    } as State;
-  const loadedState = {
-      data: [mockSampleRecord],
-      callState: LoadingState.LOADED
-    } as State;
+    ...initialState,
+    callState: LoadingState.LOADING
+  } as State;
+  const loadedState = sampleRecordAdapter.setAll([mockSampleRecord], {
+    ...initialState,
+    callState: LoadingState.LOADED
+  });
   const failedState = {
-    data: [],
-    callState: {errorMsg: "some error"}
+    ...initialState,
+    callState: { errorMsg: 'some error' }
   } as State;
 
   it('should select the sample record list', () => {
     const result = selectSampleRecordList.projector(loadedState);
-    expect(result).toBe(loadedState.data);
+    expect(result).toEqual([mockSampleRecord]);
   });
 
   it('should return null when there is no sample-record error', () => {
-    const result = getSampleRecordsError.projector(loadedState);
+    const result = getSampleRecordsError.projector(loadedState.callState);
     expect(result).toBeNull();
   });
 
   it('should select the sample-record error', () => {
-    const result = getSampleRecordsError.projector(failedState);
+    const result = getSampleRecordsError.projector(failedState.callState);
     expect(result).toBe('some error');
   });
 
   it('should tell if sample records are loading', () => {
-    const result = sampleRecordsIsLoading.projector(loadingState);
+    const result = sampleRecordsIsLoading.projector(loadingState.callState);
     expect(result).toBe(true);
   });
 
   it('should tell if sample records are not loading', () => {
-    const result = sampleRecordsIsLoading.projector(loadedState);
+    const result = sampleRecordsIsLoading.projector(loadedState.callState);
     expect(result).toBe(false);
   });
 
   it('should tell if sample records are loaded', () => {
-    const result = sampleRecordsIsLoaded.projector(loadedState);
+    const result = sampleRecordsIsLoaded.projector(loadedState.callState);
     expect(result).toBe(true);
   });
 

--- a/src/app/modules/features/sample-records/state/selectors/sample-record.selectors.ts
+++ b/src/app/modules/features/sample-records/state/selectors/sample-record.selectors.ts
@@ -1,29 +1,11 @@
-import { createFeatureSelector, createSelector } from '@ngrx/store';
-import * as fromSampleRecords from '../reducers/sample-record.reducer';
-import { LoadingState, getError } from 'src/app/modules/core/utils/call-state';
-
-const getSampleRecordsState = createFeatureSelector<fromSampleRecords.State>(
-    fromSampleRecords.sampleRecordsFeatureKey
-);
-
-export const selectSampleRecordList = createSelector(
-    getSampleRecordsState,
-    state => state.data
-);
-
-export const getSampleRecordsError = createSelector(
-    getSampleRecordsState,
-    state => getError(state.callState)
-);
-
-export const sampleRecordsIsLoading = createSelector(
-    getSampleRecordsState,
-    state => state.callState === LoadingState.LOADING
-);
-
-export const sampleRecordsIsLoaded = createSelector(
-    getSampleRecordsState,
-    state => state.callState === LoadingState.LOADED
-);
-
+export {
+  getSampleRecordsError,
+  sampleRecordsIsLoaded,
+  sampleRecordsIsLoading,
+  selectSampleRecordEntities,
+  selectSampleRecordIds,
+  selectSampleRecordList,
+  selectSampleRecordsState,
+  selectSampleRecordTotal,
+} from '../reducers/sample-record.reducer';
 


### PR DESCRIPTION
## Summary
This PR modernizes the sample feature's NgRx structure to better reflect an enterprise-oriented Angular application template.

## Changes
- migrate the sample feature reducer to `createFeature`
- use `@ngrx/entity` for sample-record collection state
- expose feature selectors from the reducer-based feature definition
- add a `SampleRecordsFacade` to separate component code from direct store access
- update the sample feature route to register state with the feature object
- update `SampleRecordsPageComponent` to load data through the facade instead of dispatching directly
- update reducer, selector, and page-component tests to match the new structure
- add facade unit tests

## Why
The previous sample feature worked, but it still looked more like a smaller tutorial-style NgRx setup than an enterprise-ready pattern. This change keeps classic NgRx Store and Effects as the backbone, while moving the example closer to a structure that scales better across teams and larger applications.

## Verification
- `npm run build`
- `npm run test:ci`

## Notes
- build passes successfully
- tests pass successfully (`69/69`)
- no intended behavior change in the feature flow
- this PR focuses on modernizing the NgRx pattern, not replacing NgRx with signals or lighter local-state approaches
