### PR TITLE
Prepare first preview release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is inspired by Keep a Changelog, and this repository uses Semantic Versioning for template milestones.
+
+## [Unreleased]
+
+## [0.1.0-beta.1] - 2026-04-26
+
+### Added
+
+- Added GitHub Actions CI for `build` and `test` on `develop`.
+- Added Dependabot configuration for Angular, NgRx, and tooling updates.
+- Added `RELEASING.md` and `BRANCH_PROTECTION.md` for the current repository workflow.
+- Added `CHANGELOG.md` to track template milestone releases.
+
+### Changed
+
+- Upgraded the template to Angular 20, NgRx 20, TypeScript 5.8, and matching build tooling.
+- Migrated the application build to `browser-esbuild`.
+- Migrated unit testing from Karma/Jasmine to Vitest.
+- Migrated the app shell and sample feature to standalone Angular bootstrap, components, and route providers.
+- Modernized the sample feature NgRx structure with `createFeature`, `@ngrx/entity`, and a facade layer.
+- Simplified the API URL layer to use `ApiUrlService`, endpoint constants, and a smaller reusable resource pattern.
+- Refreshed the README and regenerated Compodoc documentation to match the current architecture.
+
+### Removed
+
+- Removed the old `accounts` demo feature and the modal flow that only existed to support it.
+- Removed the old shared-module wrappers in favor of direct standalone component imports.
+- Removed legacy API URL builder utilities and other outdated module-based template leftovers.
+
+### Notes
+
+- This is a preview milestone release from `develop` while the repository is still using the phase 1 workflow with a single protected branch.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,12 @@ If you need a shareable tagged snapshot before `test` and `main` exist, use a pr
 - `v0.3.0-beta.1`
 - `v0.3.0-rc.1`
 
+## Current preview milestone
+
+The first release milestone for the modernized template is `v0.1.0-beta.1`.
+
+Use this as a preview release from `develop` while the repository is still in the phase 1 workflow.
+
 ## GitHub releases
 
 When you create a tagged milestone, prefer GitHub Releases with auto-generated release notes. That keeps dependency upgrades, fixes, and template changes easy to review later.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-template",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-template",
-      "version": "0.0.0",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@angular/animations": "^20.2.0",
         "@angular/cdk": "^20.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-template",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --configuration=development",


### PR DESCRIPTION
## Summary
This PR prepares the repository for the first preview release of the modernized Angular template.

## Changes
- add `CHANGELOG.md`
- set the package version to `0.1.0-beta.1`
- sync the version in `package-lock.json`
- update `RELEASING.md` with the current preview milestone guidance

## Why
The project has now gone through the main modernization steps and is in a good state for a first shareable milestone release. This PR adds the release metadata and changelog needed to make that milestone explicit and traceable.

## Notes
- this PR does not change runtime behavior
- this is a release-preparation step only
- the intended first tag after merge is `v0.1.0-beta.1`
- this is still a preview release from `develop` while the repository is using the current phase 1 workflow
